### PR TITLE
bower version up

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "outdated-browser",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "homepage": "https://github.com/burocratik/outdated-browser",
   "authors": [
     "Bürocratik <hello@burocratik.com>"


### PR DESCRIPTION
This should allow bower to fetch and install the latest v1.1.5 (2017 lowerThan:Edge) instead of 1.1.3 (2015)  

When trying to install the latest v1.1.5 (using bower) I will get installed v1.1.3 instead.
bower install complains:
...
bower outdated-browser#1.1.5         mismatch Version declared in the json (1.1.3) is different than the resolved one (1.1.5)
bower outdated-browser#1.1.5         resolved https://github.com/burocratik/outdated-browser.git#1.1.5
bower outdated-browser#1.1.5          install outdated-browser#1.1.5

outdated-browser#1.1.5 bower_components/outdated-browser